### PR TITLE
Minor Tidyup

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,9 +18,7 @@ Index
 - [Changelog](#changelog)
 
 Examples
---------
-
-Note: All examples are based on the still-unreleased `0.9.2.0-alpha`. 
+-------- 
 
 Simple example, getting the basic info for "A good day to die hard".
 

--- a/TMDbLib/project.json
+++ b/TMDbLib/project.json
@@ -1,9 +1,14 @@
 ﻿{
   "version": "1.0.0",
   "title": "TMDb Library",
-  "authors": [ "LordMike", "Naliath" ],
+  "authors": [
+    "LordMike",
+    "Naliath"
+  ],
   "packOptions": {
-    "owners": [ "LordMike" ],
+    "owners": [
+      "LordMike"
+    ],
     "requireLicenseAcceptance": false,
     "projectUrl": "https://github.com/LordMike/TMDbLib",
     "description": "TMDb Library wrapper for The Movie Database's API.",
@@ -12,22 +17,14 @@
       "url": "https://github.com/LordMike/TMDbLib"
     }
   },
-
   "dependencies": {
     "Newtonsoft.Json": "9.0.1"
   },
-
   "frameworks": {
     "netstandard1.0": {
       "imports": "dnxcore50",
       "dependencies": {
         "System.Net.Http": "4.0.0"
-      }
-    },
-    "netcoreapp1.0": {
-      "imports": "dnxcore50",
-      "dependencies": {
-        "NETStandard.Library": "1.6.0"
       }
     },
     "net45": {

--- a/TMDbLibTests/project.json
+++ b/TMDbLibTests/project.json
@@ -1,13 +1,13 @@
 ﻿{
   "version": "1.0.0-*",
   "testRunner": "xunit",
-
   "dependencies": {
     "xunit": "2.2.0-beta3-build3402",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "TMDbLib": "*"
+    "TMDbLib": {
+      "target": "project"
+    }
   },
-
   "frameworks": {
     "netcoreapp1.0": {
       "dependencies": {

--- a/TestApplication/project.json
+++ b/TestApplication/project.json
@@ -3,16 +3,16 @@
   "buildOptions": {
     "emitEntryPoint": true
   },
-
   "dependencies": {
     "Microsoft.NETCore.App": {
       "type": "platform",
       "version": "1.0.0"
     },
-    "TMDbLib": "*",
+    "TMDbLib": {
+      "target": "project"
+    },
     "Newtonsoft.Json": "9.0.1"
   },
-
   "frameworks": {
     "netcoreapp1.0": {
       "imports": "dnxcore50"


### PR DESCRIPTION
This tidies up the README and project.json

As TMDBLib is a library you dont need the netcoreapp1.0 in its project.json.

The tests and test application can also reference the library directly using `target:project`

Hope that helps a little 😄 