### PR TITLE
Implementation of Converters methods throwing NotImplementedException

### DIFF
--- a/TMDbLib/Utilities/Converters/EnumStringValueConverter.cs
+++ b/TMDbLib/Utilities/Converters/EnumStringValueConverter.cs
@@ -1,5 +1,6 @@
-using System;
 using Newtonsoft.Json;
+using System;
+using System.Reflection;
 
 namespace TMDbLib.Utilities.Converters
 {
@@ -21,7 +22,7 @@ namespace TMDbLib.Utilities.Converters
 
         public override bool CanConvert(Type objectType)
         {
-            throw new NotImplementedException();
+            return objectType.GetTypeInfo().IsEnum;
         }
     }
 }

--- a/TMDbLib/Utilities/Converters/TmdbNullIntAsZero.cs
+++ b/TMDbLib/Utilities/Converters/TmdbNullIntAsZero.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
+using System;
 
 namespace TMDbLib.Utilities.Converters
 {
@@ -20,7 +20,7 @@ namespace TMDbLib.Utilities.Converters
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            throw new NotImplementedException();
+            writer.WriteValue(value?.ToString());
         }
     }
 }

--- a/TMDbLib/Utilities/Converters/TmdbPartialDateConverter.cs
+++ b/TMDbLib/Utilities/Converters/TmdbPartialDateConverter.cs
@@ -1,5 +1,6 @@
-﻿using System;
-using Newtonsoft.Json;
+﻿using Newtonsoft.Json;
+using System;
+using System.Globalization;
 
 namespace TMDbLib.Utilities.Converters
 {
@@ -17,7 +18,7 @@ namespace TMDbLib.Utilities.Converters
                 return null;
 
             DateTime result;
-            if (!DateTime.TryParse(str, out result))
+            if (!DateTime.TryParse(str, CultureInfo.InvariantCulture.DateTimeFormat, DateTimeStyles.None, out result))
                 return null;
 
             return result;
@@ -25,7 +26,8 @@ namespace TMDbLib.Utilities.Converters
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
-            throw new NotImplementedException();
+            var date = value as DateTime?;
+            writer.WriteValue(date?.ToString(CultureInfo.InvariantCulture));
         }
     }
 }


### PR DESCRIPTION
Serializing back to JSON fails because of NotImplementedException in some Converters classes.