### PR TITLE
Bumped NET Core target frameworks of Test projects to 3.0

### DIFF
--- a/TMDbLib/TMDbLib.csproj
+++ b/TMDbLib/TMDbLib.csproj
@@ -4,7 +4,7 @@
     <AssemblyTitle>TMDb Library</AssemblyTitle>
     <VersionPrefix>1.5.0-alpha</VersionPrefix>
     <Authors>LordMike;Naliath</Authors>
-    <TargetFrameworks>net45;netstandard2.0;netstandard1.2</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.1;netstandard2.0;netstandard1.2</TargetFrameworks>
     <AssemblyName>TMDbLib</AssemblyName>
     <PackageId>TMDbLib</PackageId>
     <PackageProjectUrl>https://github.com/LordMike/TMDbLib</PackageProjectUrl>

--- a/TMDbLibTests/TMDbLibTests.csproj
+++ b/TMDbLibTests/TMDbLibTests.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>TMDbLibTests</AssemblyName>
     <PackageId>TMDbLibTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.0.0</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/TMDbLibTests/TMDbLibTests.csproj
+++ b/TMDbLibTests/TMDbLibTests.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>TMDbLibTests</AssemblyName>
     <PackageId>TMDbLibTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <RuntimeFrameworkVersion>3.0.0</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/TestApplication/TestApplication.csproj
+++ b/TestApplication/TestApplication.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp1.0</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <AssemblyName>TestApplication</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>TestApplication</PackageId>
-    <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
+    <RuntimeFrameworkVersion>3.0.0</RuntimeFrameworkVersion>
     <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>

--- a/TestApplication/TestApplication.csproj
+++ b/TestApplication/TestApplication.csproj
@@ -6,7 +6,6 @@
     <OutputType>Exe</OutputType>
     <PackageId>TestApplication</PackageId>
     <RuntimeFrameworkVersion>3.0.0</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/TestApplication/TestApplication.csproj
+++ b/TestApplication/TestApplication.csproj
@@ -5,7 +5,6 @@
     <AssemblyName>TestApplication</AssemblyName>
     <OutputType>Exe</OutputType>
     <PackageId>TestApplication</PackageId>
-    <RuntimeFrameworkVersion>3.0.0</RuntimeFrameworkVersion>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-image: Visual Studio 2017
+image: Visual Studio 2019
 build_script:
 - ps: >-
     [xml]$doc = (Get-Content .\TMDbLib\TMDbLib.csproj)


### PR DESCRIPTION
Bumped the NET Core target frameworks of the test projects to 3.0

As according to https://dotnet.microsoft.com/download/dotnet-core they've reached end of life.