### PR TITLE
Update WatchProviders.cs to resolve issue #361

### DIFF
--- a/TMDbLib/Objects/General/WatchProviders.cs
+++ b/TMDbLib/Objects/General/WatchProviders.cs
@@ -16,5 +16,11 @@ namespace TMDbLib.Objects.General
 
         [JsonProperty("buy")]
         public List<WatchProviderItem> Buy { get; set; }
+         
+        [JsonProperty("free")]
+        public List<WatchProviderItem> Free { get; set; }
+
+        [JsonProperty("ads")]
+        public List<WatchProviderItem> Ads { get; set; }
     }
 }


### PR DESCRIPTION
Proposed resolution to GET /tv/{tv_id}/watch/providers does not return WatchProviderItem for 'ads' or 'free' (#361)