### PR TITLE
Add Logos field to images.

### DIFF
--- a/TMDbLib/Objects/General/Images.cs
+++ b/TMDbLib/Objects/General/Images.cs
@@ -10,5 +10,8 @@ namespace TMDbLib.Objects.General
 
         [JsonProperty("posters")]
         public List<ImageData> Posters { get; set; }
+
+        [JsonProperty("logos")]
+        public List<ImageData> Logos { get; set; }
     }
 }


### PR DESCRIPTION
TMDb now stores logos as an image type (see [https://www.themoviedb.org/talk/5b8effd792514173b2000bb9?language=en-US&page=2](https://www.themoviedb.org/talk/5b8effd792514173b2000bb9?language=en-US&page=2)). This change will let us access the new Logos field when getting images for a movie.