### PR TITLE
TV show 'recommendations' and 'similar' as SearchContainer<SearchTv>

### DIFF
--- a/TMDbLib/Client/TMDbClientTvShows.cs
+++ b/TMDbLib/Client/TMDbClientTvShows.cs
@@ -150,9 +150,6 @@ namespace TMDbLib.Client
             if (item.AccountStates != null)
                 item.AccountStates.Id = id;
 
-            if (item.Recommendations != null)
-                item.Recommendations.Id = id;
-
             if (item.ExternalIds != null)
                 item.ExternalIds.Id = id;
 

--- a/TMDbLib/Objects/TvShows/TvShow.cs
+++ b/TMDbLib/Objects/TvShows/TvShow.cs
@@ -127,7 +127,7 @@ namespace TMDbLib.Objects.TvShows
         public List<ProductionCountry> ProductionCountries { get; set; }
 
         [JsonProperty("recommendations")]
-        public ResultContainer<TvShow> Recommendations { get; set; }
+        public SearchContainer<SearchTv> Recommendations { get; set; }
 
         [JsonProperty("reviews")]
         public SearchContainer<ReviewBase> Reviews { get; set; }
@@ -136,7 +136,7 @@ namespace TMDbLib.Objects.TvShows
         public List<SearchTvSeason> Seasons { get; set; }
 
         [JsonProperty("similar")]
-        public ResultContainer<TvShow> Similar { get; set; }
+        public SearchContainer<SearchTv> Similar { get; set; }
 
         [JsonProperty("spoken_languages")]
         public List<SpokenLanguage> SpokenLanguages { get; set; }


### PR DESCRIPTION
This way it fits better to the API, and matches `Movie.cs`.